### PR TITLE
Added config to disable worm-only nest targetting.

### DIFF
--- a/autotargeter.lua
+++ b/autotargeter.lua
@@ -6,9 +6,11 @@ function findNestNear(entity)
 	if #spawners > 0 then
 		return spawners[math.random(#spawners)]
 	end
-	local worms = entity.surface.find_entities_filtered{area = search, type = "turret"}
-	if #worms > 0 then
-		return worms[math.random(#worms)]
+	if targetWorms then
+		local worms = entity.surface.find_entities_filtered{area = search, type = "turret"}
+		if #worms > 0 then
+			return worms[math.random(#worms)]
+		end
 	end
 	return false
 end

--- a/config.lua
+++ b/config.lua
@@ -44,5 +44,8 @@ lockoutTicks = 10
 -- Higher values may result in reduced performance.
 autoTargetRange = 250
 
+-- Should the Auto-Targeting Station target worm-only nests?
+autoTargetWorms = true
+
 -- Print messages to the console whenever an ion cannon fires or an auto-targeting station acquires a target
 printMessages = false


### PR DESCRIPTION
This is for those of us who don't want the OIC to auto-target worms. The default setting keeps the current behavior.
