### PR TITLE
Updated to 0.13

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -1,3 +1,10 @@
+Orbital Ion Cannon 2.0.0
+========================
+
+Version 2.0.0 was released June 30, 2016 and was tested using Factorio v0.13.1.
+
+Mod should mostly function like 1.2.3, just in 0.13 instead. It does keep your satelittes etc from 0.12, but the mod itself can no longer be used in 0.12.
+
 Orbital Ion Cannon 1.2.3
 ========================
 

--- a/control.lua
+++ b/control.lua
@@ -1,5 +1,4 @@
 require "util"
-require "defines"
 require "stdlib/game"
 require "stdlib/event/event"
 require "config"

--- a/info.json
+++ b/info.json
@@ -1,9 +1,10 @@
 {
   "name": "Orbital Ion Cannon",
-  "version": "1.2.3",
+  "version": "2.0.0",
   "title": "Orbital Ion Cannon",
-  "author": "Supercheese",
+  "author": "Supercheese, updated by Danielv123",
+  "factorio_version": "0.13",
   "homepage": "http://www.factorioforums.com/forum/viewtopic.php?f=93&t=17910",
-  "dependencies": ["base >= 0.12.17", "? bobwarfare >= 0.12.0", "? bobpower >= 0.12.0", "? bobtech >= 0.12.0", "? bobelectronics >= 0.12.0"],
+  "dependencies": ["base >= 0.13.0", "? bobwarfare >= 0.12.0", "? bobpower >= 0.12.0", "? bobtech >= 0.12.0", "? bobelectronics >= 0.12.0"],
   "description": "When you need to call down the thunder to deal with those pesky biters, launch a rocket with an ion cannon into orbit and show the bugs who's boss."
 }

--- a/prototypes/entities.lua
+++ b/prototypes/entities.lua
@@ -177,6 +177,14 @@ data:extend({
 		{
 			sound = { filename = "__base__/sound/train-stop.ogg", volume = 0 }
 		},
+		circuit_wire_connection_points = {},
+		circuit_connector_sprites =
+		{
+			get_circuit_connector_sprites({0.5625-1, 1.03125}, {0.5625-1, 1.03125}, 0), --N
+			get_circuit_connector_sprites({-0.78125, 0.28125-1}, {-0.78125, 0.28125-1}, 6), --E
+			get_circuit_connector_sprites({-0.28125+1, 0.28125}, {-0.28125+1, 0.28125}, 0), --S
+			get_circuit_connector_sprites({0.03125, 0.28125+1}, {0.03125, 0.28125+1}, 6), --W
+		},
 	},
 
 	{

--- a/prototypes/recipes.lua
+++ b/prototypes/recipes.lua
@@ -8,7 +8,7 @@ data:extend({
 		{
 			{"low-density-structure", 100},
 			{"solar-panel", 100},
-			{"basic-accumulator", 200},
+			{"accumulator", 200},
 			{"radar", 10},
 			{"processing-unit", 200},
 			{"electric-engine-unit", 25},


### PR DESCRIPTION
All of the mods function (should) remain intact, but it seems to run fine in 0.13 now. I have tried to do the absolute minimum of code changes, but added a small change to the readme. My fork will also include the version 2.0.0 release.

Incremented major version as you can no longer use the mod in 0.12.
