### PR TITLE
added revealed range parameter to config

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -40,10 +40,14 @@ proximityCheck = false
 -- For example, setting this value to 120 would mean that there is always a minimum of two seconds between ion cannon blasts; any attempt to target the ion cannon in the two seconds following a prior targeting would fail.
 lockoutTicks = 10
 
--- The range, in chunks, of the Auto-Targeting Station.
+-- The range, in chunks, of the Auto-Targeting Station scanning.
 -- Each chunk is 32x32 tiles, so the default radius of 10 would gradually scan a 640x640 region (20-chunk diameter).
 -- Higher values should have no appreciable effect on performance, but each station will take longer to go back and re-scan old regions when the range is higher.
 autoTargetRange = 10
+
+-- The range, in chunks, of permanently revealed area by Auto-Targeting Stations.
+-- A radius of 3 is equal to base radar.
+autoTargetRevealed = 3
 
 -- Whether the Auto-Targeting Station should target worms as well as nests
 autoTargetWorms = true

--- a/prototypes/entities.lua
+++ b/prototypes/entities.lua
@@ -509,7 +509,7 @@ auto_targeter.pictures =
 		}
 auto_targeter.energy_per_sector = "2MJ"
 auto_targeter.max_distance_of_sector_revealed = autoTargetRange
-auto_targeter.max_distance_of_nearby_sector_revealed = 1
+auto_targeter.max_distance_of_nearby_sector_revealed = autoTargetRevealed
 auto_targeter.energy_usage = "500kW"
 
 data:extend({auto_targeter})


### PR DESCRIPTION
Added a config parameter to set the area permanently revealed by auto targeter radars.