### PR TITLE
Add long-range auto-targetting radars ala Bobs

### DIFF
--- a/autotargeter.lua
+++ b/autotargeter.lua
@@ -17,7 +17,7 @@ end
 
 script.on_event(defines.events.on_sector_scanned, function(event)
 	local radar = event.radar
-	if radar.name == "auto-targeter" then
+	if string.match(radar.name, "auto%-targeter") then -- Note escape hyphen
 		local target = findNestNear(radar, event.chunk_position)
 		if target then
 			local fired = targetIonCannon(radar.force, target.position, radar.surface)

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,6 +1,18 @@
 if data.raw["tool"]["science-pack-4"] and enableBobUpdates then
 	data.raw["technology"]["orbital-ion-cannon"].unit.ingredients[5] = {"science-pack-4", 2}
 	data.raw["technology"]["auto-targeting"].unit.ingredients[5] = {"science-pack-4", 1}
+  if data.raw["technology"]["auto-targeting-2"] then
+    data.raw["technology"]["auto-targeting-2"].unit.ingredients[5] = {"science-pack-4", 1}
+  end
+  if data.raw["technology"]["auto-targeting-3"] then
+    data.raw["technology"]["auto-targeting-3"].unit.ingredients[5] = {"science-pack-4", 1}
+  end
+  if data.raw["technology"]["auto-targeting-4"] then
+    data.raw["technology"]["auto-targeting-4"].unit.ingredients[5] = {"science-pack-4", 1}
+  end
+  if data.raw["technology"]["auto-targeting-5"] then
+    data.raw["technology"]["auto-targeting-5"].unit.ingredients[5] = {"science-pack-4", 1}
+  end
 end
 
 if not data.raw["assembling-machine"]["assembling-machine-4"] then

--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -27,20 +27,36 @@ auto-target-designated = Auto-Targeting Station __1__ has identified an enemy ne
 orbital-ion-cannon = Orbital Ion Cannon
 ion-cannon-targeter = Ion Cannon Targeting Device
 auto-targeter = Auto-Targeting Station
+auto-targeter-2 = Auto-Targeting Station Mk2
+auto-targeter-3 = Auto-Targeting Station Mk3
+auto-targeter-4 = Auto-Targeting Station Mk4
+auto-targeter-5 = Auto-Targeting Station Mk5
 
 [item-description]
 ion-cannon-targeter = Use this device to designate a target for your orbital ion cannon(s)
 orbital-ion-cannon = Launch this ion cannon into orbit within a rocket and you will be able to utilize its massive firepower
 auto-targeter = Auto-Targeting Stations periodically scan for Spawners and if any are found, they will automatically designate them as targets for your ion cannons in orbit
+auto-targeter-2 = Auto-Targeting Stations periodically scan for Spawners and if any are found, they will automatically designate them as targets for your ion cannons in orbit
+auto-targeter-3 = Auto-Targeting Stations periodically scan for Spawners and if any are found, they will automatically designate them as targets for your ion cannons in orbit
+auto-targeter-4 = Auto-Targeting Stations periodically scan for Spawners and if any are found, they will automatically designate them as targets for your ion cannons in orbit
+auto-targeter-5 = Auto-Targeting Stations periodically scan for Spawners and if any are found, they will automatically designate them as targets for your ion cannons in orbit
 
 [entity-name]
 ion-cannon-targeter = Ion Cannon Targeting Device
 ion-cannon-target = Number of times an ion cannon was fired
 auto-targeter = Auto-Targeting Station
+auto-targeter-2 = Auto-Targeting Station Mk2
+auto-targeter-3 = Auto-Targeting Station Mk3
+auto-targeter-4 = Auto-Targeting Station Mk4
+auto-targeter-5 = Auto-Targeting Station Mk5
 
 [technology-name]
 orbital-ion-cannon = Orbital Ion Cannon
 auto-targeting = Auto-Targeting
+auto-targeting2 = Auto-Targeting 2
+auto-targeting3 = Auto-Targeting 3
+auto-targeting4 = Auto-Targeting 4
+auto-targeting5 = Auto-Targeting 5
 
 [controls]
 ion-cannon-hotkey = Toggle Ion Cannon GUI

--- a/prototypes/entities.lua
+++ b/prototypes/entities.lua
@@ -515,6 +515,95 @@ auto_targeter.energy_usage = "500kW"
 
 data:extend({auto_targeter})
 
+if data.raw["radar"]["radar-2"] and enableBobUpdates then
+  local auto_targeter_2 = util.table.deepcopy(data.raw["radar"]["radar-2"])
+
+  auto_targeter_2.name = "auto-targeter-2"
+  auto_targeter_2.icon = "__Orbital Ion Cannon__/graphics/AutoTargeter.png"
+  auto_targeter_2.minable = {hardness = 0.2, mining_time = 0.5, result = "auto-targeter-2"}
+  auto_targeter_2.pictures =
+      {
+        filename = "__Orbital Ion Cannon__/graphics/Auto-Target-Entity.png",
+        priority = "low",
+        width = 153,
+        height = 131,
+        apply_projection = false,
+        direction_count = 64,
+        line_length = 8,
+        shift = {0.875, -0.34375}
+      }
+  auto_targeter_2.energy_per_sector = "5MJ"
+  auto_targeter_2.energy_usage = "750kW"
+
+  data:extend({auto_targeter_2})
+end
+if data.raw["radar"]["radar-3"] and enableBobUpdates then
+  local auto_targeter3 = util.table.deepcopy(data.raw["radar"]["radar-3"])
+
+  auto_targeter3.name = "auto-targeter-3"
+  auto_targeter3.icon = "__Orbital Ion Cannon__/graphics/AutoTargeter.png"
+  auto_targeter3.minable = {hardness = 0.2, mining_time = 0.5, result = "auto-targeter-3"}
+  auto_targeter3.pictures =
+      {
+        filename = "__Orbital Ion Cannon__/graphics/Auto-Target-Entity.png",
+        priority = "low",
+        width = 153,
+        height = 131,
+        apply_projection = false,
+        direction_count = 64,
+        line_length = 8,
+        shift = {0.875, -0.34375}
+      }
+  auto_targeter3.energy_per_sector = "10MJ"
+  auto_targeter3.energy_usage = "1MW"
+
+  data:extend({auto_targeter3})
+end
+if data.raw["radar"]["radar-4"] and enableBobUpdates then
+  local auto_targeter4 = util.table.deepcopy(data.raw["radar"]["radar-4"])
+
+  auto_targeter4.name = "auto-targeter-4"
+  auto_targeter4.icon = "__Orbital Ion Cannon__/graphics/AutoTargeter.png"
+  auto_targeter4.minable = {hardness = 0.2, mining_time = 0.5, result = "auto-targeter-4"}
+  auto_targeter4.pictures =
+      {
+        filename = "__Orbital Ion Cannon__/graphics/Auto-Target-Entity.png",
+        priority = "low",
+        width = 153,
+        height = 131,
+        apply_projection = false,
+        direction_count = 64,
+        line_length = 8,
+        shift = {0.875, -0.34375}
+      }
+  auto_targeter4.energy_per_sector = "15MJ"
+  auto_targeter4.energy_usage = "1.25MW"
+
+  data:extend({auto_targeter4})
+end
+if data.raw["radar"]["radar-5"] and enableBobUpdates then
+  local auto_targeter5 = util.table.deepcopy(data.raw["radar"]["radar-5"])
+
+  auto_targeter5.name = "auto-targeter-5"
+  auto_targeter5.icon = "__Orbital Ion Cannon__/graphics/AutoTargeter.png"
+  auto_targeter5.minable = {hardness = 0.2, mining_time = 0.5, result = "auto-targeter-5"}
+  auto_targeter5.pictures =
+      {
+        filename = "__Orbital Ion Cannon__/graphics/Auto-Target-Entity.png",
+        priority = "low",
+        width = 153,
+        height = 131,
+        apply_projection = false,
+        direction_count = 64,
+        line_length = 8,
+        shift = {0.875, -0.34375}
+      }
+  auto_targeter5.energy_per_sector = "20MJ"
+  auto_targeter5.energy_usage = "1.5MW"
+
+  data:extend({auto_targeter5})
+end
+
 if not ionCannonFlames then
 	data.raw["projectile"]["crosshairs"].action =
 	{

--- a/prototypes/items.lua
+++ b/prototypes/items.lua
@@ -30,3 +30,60 @@ data:extend({
 		stack_size = 5
 	},
 })
+
+if enableBobUpdates and data.raw["item"]["radar-2"] then
+  data:extend({
+    {
+      type = "item",
+      name = "auto-targeter-2",
+      icon = "__Orbital Ion Cannon__/graphics/AutoTargeter.png",
+      flags = {"goes-to-quickbar"},
+      place_result = "auto-targeter-2",
+      subgroup = "defensive-structure",
+      order = "e[orbital-ion-cannon]-a[auto]",
+      stack_size = 5
+    },
+  })
+end
+if enableBobUpdates and data.raw["item"]["radar-3"] then
+  data:extend({
+    {
+      type = "item",
+      name = "auto-targeter-3",
+      icon = "__Orbital Ion Cannon__/graphics/AutoTargeter.png",
+      flags = {"goes-to-quickbar"},
+      place_result = "auto-targeter-3",
+      subgroup = "defensive-structure",
+      order = "e[orbital-ion-cannon]-a[auto]",
+      stack_size = 5
+    },
+  })
+end
+if enableBobUpdates and data.raw["item"]["radar-4"] then
+  data:extend({
+    {
+      type = "item",
+      name = "auto-targeter-4",
+      icon = "__Orbital Ion Cannon__/graphics/AutoTargeter.png",
+      flags = {"goes-to-quickbar"},
+      place_result = "auto-targeter-4",
+      subgroup = "defensive-structure",
+      order = "e[orbital-ion-cannon]-a[auto]",
+      stack_size = 5
+    },
+  })
+end
+if enableBobUpdates and data.raw["item"]["radar-5"] then
+  data:extend({
+    {
+      type = "item",
+      name = "auto-targeter-5",
+      icon = "__Orbital Ion Cannon__/graphics/AutoTargeter.png",
+      flags = {"goes-to-quickbar"},
+      place_result = "auto-targeter-5",
+      subgroup = "defensive-structure",
+      order = "e[orbital-ion-cannon]-a[auto]",
+      stack_size = 5
+    },
+  })
+end

--- a/prototypes/recipes.lua
+++ b/prototypes/recipes.lua
@@ -60,3 +60,77 @@ if data.raw["item"]["fast-accumulator-3"] and data.raw["item"]["solar-panel-larg
 	data.raw["recipe"]["orbital-ion-cannon"].ingredients[2] = {"solar-panel-large-3", 100}
 	data.raw["recipe"]["orbital-ion-cannon"].ingredients[3] = {"fast-accumulator-3", 200}
 end
+
+-- If we have radar-2, assume we have bobs?
+if data.raw["item"]["radar-2"] and enableBobUpdates then
+  data:extend({
+    {
+      type = "recipe",
+      name = "auto-targeter-2",
+      energy_required = 5,
+      enabled = false,
+      category = "crafting",
+      ingredients =
+      {
+        {"radar-2", 1},
+        {"electronic-circuit", 20},
+        {"auto-targeter", 1}
+      },
+      result= "auto-targeter-2"
+    },
+  })
+end
+if data.raw["item"]["radar-3"] and enableBobUpdates then
+  data:extend({
+    {
+      type = "recipe",
+      name = "auto-targeter-3",
+      energy_required = 5,
+      enabled = false,
+      category = "crafting",
+      ingredients =
+      {
+        {"radar-3", 1},
+        {"advanced-circuit", 20},
+        {"auto-targeter-2", 1}
+      },
+      result= "auto-targeter-3"
+    },
+  })
+end
+if data.raw["item"]["radar-4"] and enableBobUpdates then
+  data:extend({
+    {
+      type = "recipe",
+      name = "auto-targeter-4",
+      energy_required = 5,
+      enabled = false,
+      category = "crafting",
+      ingredients =
+      {
+        {"radar-4", 1},
+        {"processing-unit", 20},
+        {"auto-targeter-3", 1}
+      },
+      result= "auto-targeter-4"
+    },
+  })
+end
+if data.raw["item"]["radar-5"] and enableBobUpdates then
+  data:extend({
+    {
+      type = "recipe",
+      name = "auto-targeter-5",
+      energy_required = 5,
+      enabled = false,
+      category = "crafting",
+      ingredients =
+      {
+        {"radar-5", 1},
+        {"advanced-processing-unit", 50},
+        {"auto-targeter-4", 1}
+      },
+      result= "auto-targeter-5"
+    },
+  })
+end

--- a/prototypes/technologies.lua
+++ b/prototypes/technologies.lua
@@ -64,3 +64,125 @@ end
 if data.raw["item"]["fast-accumulator-3"] and data.raw["item"]["solar-panel-large-3"] and data.raw["item"]["bob-laser-turret-5"] and enableBobUpdates then
 	data.raw["technology"]["orbital-ion-cannon"].prerequisites = {"rocket-silo", "laser-turret-damage-6", "bob-solar-energy-4", "bob-electric-energy-accumulators-4", "bob-laser-turrets-5"}
 end
+
+-- Assume that if we have radars and Bobs, we have science-pack-4
+if data.raw["technology"]["radars"] and enableBobUpdates then
+data:extend({
+	{
+		type = "technology",
+		name = "auto-targeting-2",
+		icon = "__Orbital Ion Cannon__/graphics/AutoTargetingTech.png",
+		prerequisites = {"auto-targeting", "radars"},
+		effects =
+		{
+			{
+			type = "unlock-recipe",
+			recipe = "auto-targeter-2"
+			},
+		},
+		unit =
+		{
+			count = 1200,
+			ingredients =
+			{
+			{"science-pack-1", 1},
+			{"science-pack-2", 1},
+			{"science-pack-3", 1},
+			{"alien-science-pack", 1},
+			},
+			time = 60
+		},
+		order = "k-b-b"
+	},
+})
+end
+if data.raw["technology"]["radars-2"] and enableBobUpdates then
+data:extend({
+	{
+		type = "technology",
+		name = "auto-targeting-3",
+		icon = "__Orbital Ion Cannon__/graphics/AutoTargetingTech.png",
+		prerequisites = {"auto-targeting-2", "radars-2"},
+		effects =
+		{
+			{
+			type = "unlock-recipe",
+			recipe = "auto-targeter-3"
+			},
+		},
+		unit =
+		{
+			count = 1400,
+			ingredients =
+			{
+			{"science-pack-1", 1},
+			{"science-pack-2", 1},
+			{"science-pack-3", 1},
+			{"alien-science-pack", 1},
+			},
+			time = 60
+		},
+		order = "k-b-c"
+	},
+})
+end
+if data.raw["technology"]["radars-3"] and enableBobUpdates then
+data:extend({
+	{
+		type = "technology",
+		name = "auto-targeting-4",
+		icon = "__Orbital Ion Cannon__/graphics/AutoTargetingTech.png",
+		prerequisites = {"auto-targeting-3", "radars-3"},
+		effects =
+		{
+			{
+			type = "unlock-recipe",
+			recipe = "auto-targeter-4"
+			},
+		},
+		unit =
+		{
+			count = 1600,
+			ingredients =
+			{
+			{"science-pack-1", 1},
+			{"science-pack-2", 1},
+			{"science-pack-3", 1},
+			{"alien-science-pack", 1},
+			},
+			time = 60
+		},
+		order = "k-b-d"
+	},
+})
+end
+if data.raw["technology"]["radars-4"] and enableBobUpdates then
+data:extend({
+	{
+		type = "technology",
+		name = "auto-targeting-5",
+		icon = "__Orbital Ion Cannon__/graphics/AutoTargetingTech.png",
+		prerequisites = {"auto-targeting-4", "radars-4"},
+		effects =
+		{
+			{
+			type = "unlock-recipe",
+			recipe = "auto-targeter-5"
+			},
+		},
+		unit =
+		{
+			count = 1800,
+			ingredients =
+			{
+			{"science-pack-1", 1},
+			{"science-pack-2", 1},
+			{"science-pack-3", 1},
+			{"alien-science-pack", 1},
+			},
+			time = 60
+		},
+		order = "k-b-e"
+	},
+})
+end


### PR DESCRIPTION
I missed having the long-range radars of Bob's, so I added 4 more levels of auto-targeters. Note that these have the exact same range as Bob's radars at equivalent levels, not diminished like the very first auto-targeter. I have no idea if the material cost is balanced, but they can get expensive as they depend on having the same-level radar, as well as previous level auto targeter (which itself required previous-level radar also).

Research costs are just 1200/1400/1600/1800. It's expensive, but if you're going to use them then you probably have the factory to support them. They still only target chunks being scanned, rather than those in constant vision, so you have to slowly clear out before building bigger scanners.