### PR TITLE
Don't destroy targeter when player is denied permission

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -333,7 +333,7 @@ script.on_event(defines.events.on_player_cursor_stack_changed, function(event)
 			if not global.permissions[index] then
 				player.print({"ion-permission-denied"})
 				playSoundForPlayer("unable-to-comply", player)
-				return player.cursor_stack.clear()
+				return player.clean_cursor()
 			end
 		end
 		if (player.cheat_mode or (#global.forces_ion_cannon_table[player.force.name] > 0 and not isAllIonCannonOnCooldown(player))) and not global.holding_targeter[index] then


### PR DESCRIPTION
Calling `player.cursor_stack.clear()` voids the held item. Calling `player.clean_cursor()` instead just clears the cursor and sends the targeter to the inventory, as if the player pressed (by default) Q.

Discovered the hard way that our multiplayer game's ion cannon permissions were set wrong, and the affected player had to go halfway across the map to get materials for a new targeting remote.